### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 A Home Assistant add-on designed to act as a proxy between [Ecoqube](https://ecosense.io/products/ecoqube) radon devices. 
 
 ## How it Works
-Ecoqube devices seem to make requests to the Ecosense API every ~10 minutes. They do not verify the servers ceritifcate though which means we can impersonate the Ecosense server and capture the data.
+Ecoqube devices seem to make requests to the Ecosense API every ~10 minutes. They do not verify the servers ceritifcate though which means we can man in the middle the Ecosense server and capture the data.
+
+This sets up a webserver that will intercept and forward queries to the Ecosense server capture the data and publish it over MQTT.
 
 ## Setup Instructions
 
@@ -48,7 +50,7 @@ Installing the Ecosense Add-On. This communicates directly with the Ecoqube devi
 
 #### Configure your local DNS
 
-You need to add to your network DNS (via Pi-hole, pfSense, or some other method) the following domain to point to your Home Assistant IP address:
+You need to add to your network DNS (via Pi-hole, pfSense, AdGuardHome or some other method) the following domain to point to your Home Assistant IP address:
 
 - api.cloud.ecosense.io
 
@@ -56,7 +58,7 @@ This tells the Ecosense device connected to your network that when it does an up
 
 #### Connect the Ecosense Device
 
-If you've done all of this correctly, the controller should begin reporting data to the Energy Smart Bridge, which in turn reports it to Mosquitto broker. Entities should be automatically created in your Home Assistant.
+If you've done all of this correctly, the controller should begin reporting data to the Ecosense addon, which in turn reports it to Mosquitto broker. Entities should be automatically created in your Home Assistant.
 
 ## Credits
  [Dave Goldberg's blog post](https://embeddedartistry.com/blog/2024/11/04/reclaim-your-data-freeing-a-wi-fi-sensor-from-the-cloud/#Replacing-Their-Servers-With-Our-Own) 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Home Assistant add-on designed to act as a proxy between [Ecoqube](https://eco
 ## How it Works
 Ecoqube devices seem to make requests to the Ecosense API every ~10 minutes. They do not verify the servers ceritifcate though which means we can man in the middle the Ecosense server and capture the data.
 
-This sets up a webserver that will intercept and forward queries to the Ecosense server capture the data and publish it over MQTT.
+This sets up a webserver that will intercept and forward queries to the Ecosense server capture the data and publish it over MQTT. All data will still be forwarded to ecosense to the EcoQube app will continue to function.
 
 ## Setup Instructions
 
@@ -55,6 +55,8 @@ You need to add to your network DNS (via Pi-hole, pfSense, AdGuardHome or some o
 - api.cloud.ecosense.io
 
 This tells the Ecosense device connected to your network that when it does an update instead of talking to the Ecosense api, to instead talk to the Ecosense add-on instead.
+
+**Note: If you want to continue to use the EcoQube app will connected to your lan, you will want to make sure you only point the EcoCube device to your home assistant instance, the EcoCube app on your phone will still need to be able to get the actual IP of the ecosense server.**
 
 #### Connect the Ecosense Device
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Home Assistant add-on designed to act as a proxy between [Ecoqube](https://eco
 ## How it Works
 Ecoqube devices seem to make requests to the Ecosense API every ~10 minutes. They do not verify the servers ceritifcate though which means we can man in the middle the Ecosense server and capture the data.
 
-This sets up a webserver that will intercept and forward queries to the Ecosense server capture the data and publish it over MQTT. All data will still be forwarded to ecosense to the EcoQube app will continue to function.
+This sets up a webserver that will intercept queries from the EcoQube device, forward them to the Ecosense server, capture the data, and publish it over MQTT. Note that all measurement data will still be forwarded to ecosense, and you will still be able to view it in EcoQube app.
 
 ## Setup Instructions
 
@@ -56,11 +56,11 @@ You need to add to your network DNS (via Pi-hole, pfSense, AdGuardHome or some o
 
 This tells the Ecosense device connected to your network that when it does an update instead of talking to the Ecosense api, to instead talk to the Ecosense add-on instead.
 
-**Note: If you want to continue to use the EcoQube app will connected to your lan, you will want to make sure you only point the EcoCube device to your home assistant instance, the EcoCube app on your phone will still need to be able to get the actual IP of the ecosense server.**
+**Note: If you want to continue to use the EcoQube app while you are connected to your lan, you will want to make sure your DNS only redirects the EcoCube device to your home assistant instance, the EcoCube app on your phone will still need to be able to get the actual IP of the ecosense server.**
 
 #### Connect the Ecosense Device
 
-If you've done all of this correctly, the controller should begin reporting data to the Ecosense addon, which in turn reports it to Mosquitto broker. Entities should be automatically created in your Home Assistant.
+If you've done all of this correctly, the controller should begin reporting data to the Addon/Container, which in turn reports it to Mosquitto broker. Entities should be automatically created in your Home Assistant.
 
 ## Credits
  [Dave Goldberg's blog post](https://embeddedartistry.com/blog/2024/11/04/reclaim-your-data-freeing-a-wi-fi-sensor-from-the-cloud/#Replacing-Their-Servers-With-Our-Own) 


### PR DESCRIPTION
First off brilliant project!

This PR adds some minor clarifications in the readme.

When I set this up I was under the impression this would impersonate only rather than act as true man in the middle. So I was a bit surprised to find this was performing a DNS query and then  still talking to the ecosense servers.

In addition to the changes below I do have a couple questions that may or may not be worth answering in the readme, or could potentially lead to future features, and perhaps a warning:

1. Is this still supposed to relay data to the ecosense server in addition to publishing on MQTT, or is it not? The answer is Yes. ~~It seems to me the answer is yes but I'm not very familiar with JS so maybe I'm reading it wrong, and due to the issue below i don't seem to be able to use the Ecosense app so I can't verify. If the intended behavior is that it get reported to ecosense that should probably be stated in the README and maybe a future feature would be to add a config option to swallow or forward the data. I have started a branch in my fork for this but haven't had a chance to test it yet.~~

~~1. Now for the warning part:~~

 - ~~TLDR I tried to configure my router to let me use a port other than 443, as a result of misconfiguration I think it caused my device to behave irregularly which perhaps got my device banned by ecosense, when I open the ecosense app it says i have no registered devices and I don't seem to be able to register it again either. This isn't too much of a problem because my data is being published in homeassistant now where I have control of it, but I did lose my past 6mo of history which is a bummer. So it may be worth adding a warning to the readme.~~

 - ~~Initially i was trying to configure this to run on a port other than 443 as i already use that on my HA instance, that's easy enough to configure in this addon, but then some sort of external method is needed to relay the traffic from port 443 to the new port. I tried to do this through OpenWRT NAT rules and while i was able to get my router to forward the traffic, it was only working in one direction, so the IP addresses of the response weren't what the ecoqube was expecting so it would reset and reinitiate the connection repeatedly.~~


