### PR TITLE
Add state_class to MQTT publish config

### DIFF
--- a/ecosense/src/mqtt.js
+++ b/ecosense/src/mqtt.js
@@ -24,6 +24,7 @@ export const publish_config = async (serial_number, fw_version) => {
     await MQTT.publishAsync(`homeassistant/sensor/${serial_number}/radon/config`, JSON.stringify({
         "state_topic": `homeassistant/sensor/${serial_number}/radon/state`,
         "unit_of_measurement":"Bq/m³",
+        "state_class":"measurement",
         "unique_id": `${serial_number}-radon`,
         name: 'Radon',
         ...generateDeviceConfig(serial_number, fw_version),


### PR DESCRIPTION
Since state_class is missing no statistics are created for this sensor value. Thus adding will fix this.